### PR TITLE
feat: add support for SM64COOPDX save files

### DIFF
--- a/src/Game/SaveFile.cpp
+++ b/src/Game/SaveFile.cpp
@@ -124,19 +124,15 @@ SaveFileTypes SaveFile::CalculateType(SaveData* saveData)
 	if (saveData == nullptr) return SaveFileTypes::NotValid;
 
 	bool hasLeSlot = (saveData->saveSlots[0][0].Magic == SAVE_SLOT_MAGIC_LE || saveData->saveSlots[0][1].Magic == SAVE_SLOT_MAGIC_LE);
-	bool hasLeSettings = (saveData->settings[0].Magic == SETTINGS_DATA_MAGIC_LE || saveData->settings[1].Magic == SETTINGS_DATA_MAGIC_LE);
 
-	bool hasBeSlot = (saveData->saveSlots[0][0].Magic == SAVE_SLOT_MAGIC_BE || saveData->saveSlots[0][1].Magic == SAVE_SLOT_MAGIC_BE);
-	bool hasBeSettings = (saveData->settings[0].Magic == SETTINGS_DATA_MAGIC_BE || saveData->settings[1].Magic == SETTINGS_DATA_MAGIC_BE);
-
-	bool hasNoSettings = (saveData->settings[0].Magic == 0 && saveData->settings[1].Magic == 0);
-
-	if (hasLeSlot && (hasLeSettings || hasNoSettings))
+	if (hasLeSlot)
 	{
 		return SaveFileTypes::LittleEndian;
 	}
 
-	if (hasBeSlot && (hasBeSettings || hasNoSettings))
+	bool hasBeSlot = (saveData->saveSlots[0][0].Magic == SAVE_SLOT_MAGIC_BE || saveData->saveSlots[0][1].Magic == SAVE_SLOT_MAGIC_BE);
+
+	if (hasBeSlot)
 	{
 		return SaveFileTypes::BigEndian;
 	}

--- a/src/Game/SaveFile.cpp
+++ b/src/Game/SaveFile.cpp
@@ -123,14 +123,20 @@ SaveFileTypes SaveFile::CalculateType(SaveData* saveData)
 {
 	if (saveData == nullptr) return SaveFileTypes::NotValid;
 
-	if ((saveData->saveSlots[0][0].Magic == SAVE_SLOT_MAGIC_LE || saveData->saveSlots[0][1].Magic == SAVE_SLOT_MAGIC_LE) &&
-		(saveData->settings[0].Magic == SETTINGS_DATA_MAGIC_LE || saveData->settings[1].Magic == SETTINGS_DATA_MAGIC_LE))
+	bool hasLeSlot = (saveData->saveSlots[0][0].Magic == SAVE_SLOT_MAGIC_LE || saveData->saveSlots[0][1].Magic == SAVE_SLOT_MAGIC_LE);
+	bool hasLeSettings = (saveData->settings[0].Magic == SETTINGS_DATA_MAGIC_LE || saveData->settings[1].Magic == SETTINGS_DATA_MAGIC_LE);
+
+	bool hasBeSlot = (saveData->saveSlots[0][0].Magic == SAVE_SLOT_MAGIC_BE || saveData->saveSlots[0][1].Magic == SAVE_SLOT_MAGIC_BE);
+	bool hasBeSettings = (saveData->settings[0].Magic == SETTINGS_DATA_MAGIC_BE || saveData->settings[1].Magic == SETTINGS_DATA_MAGIC_BE);
+
+	bool hasNoSettings = (saveData->settings[0].Magic == 0 && saveData->settings[1].Magic == 0);
+
+	if (hasLeSlot && (hasLeSettings || hasNoSettings))
 	{
 		return SaveFileTypes::LittleEndian;
 	}
 
-	if ((saveData->saveSlots[0][0].Magic == SAVE_SLOT_MAGIC_BE || saveData->saveSlots[0][1].Magic == SAVE_SLOT_MAGIC_BE) &&
-		(saveData->settings[0].Magic == SETTINGS_DATA_MAGIC_BE || saveData->settings[1].Magic == SETTINGS_DATA_MAGIC_BE))
+	if (hasBeSlot && (hasBeSettings || hasNoSettings))
 	{
 		return SaveFileTypes::BigEndian;
 	}


### PR DESCRIPTION
This PR adds support for reading and editing save files generated by **SM64COOPDX**. Previously, the save editor only supported files from the Emulator and PC Port versions.

## What was changed
- Refactored the conditional logic in `SaveFile::CalculateType` (`src/Game/SaveFile.cpp`).
- Added the `hasNoSettings` flag to handle files where both `saveData->settings[0].Magic` and `saveData->settings[1].Magic` equal `0`.
- The save format (BigEndian or LittleEndian) is now inferred if the *Slots* are valid alongside valid *Settings*, **OR** if the *Settings* are simply zeroed out.